### PR TITLE
Upgrade rust-lightning and expose more

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,8 @@ repository = "https://github.com/BoltzExchange/bolt12-wasm.git"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-bech32 = { version = "0.9.1", default-features = false }
-lightning = { version = "0.0.125", features = ["no-std"], default-features = false }
+bech32 = { version = "0.11.0", default-features = false }
+lightning = { version = "0.1.1", features = [], default-features = false }
 wasm-bindgen = "0.2.95"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@ impl Offer {
     pub fn quantity(&self) -> Option<u64> {
         match self.offer.supported_quantity() {
             lightning::offers::offer::Quantity::Bounded(n) => Some(n.get()),
-            lightning::offers::offer::Quantity::Unbounded => Some(0),
+            lightning::offers::offer::Quantity::Unbounded => None,
             lightning::offers::offer::Quantity::One => Some(1),
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,7 @@ pub struct Invoice {
 impl Invoice {
     #[wasm_bindgen(constructor)]
     pub fn new(invoice: &str) -> Result<Invoice, String> {
-        let p = match CheckedHrpstring::new::<NoChecksum>(&invoice) {
+        let p = match CheckedHrpstring::new::<NoChecksum>(invoice) {
             Ok(res) => res,
             Err(err) => return Err(format!("{:?}", err)),
         };

--- a/src/path.rs
+++ b/src/path.rs
@@ -32,8 +32,8 @@ impl Hop {
 #[wasm_bindgen(inspectable)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct DirectedShortChannelId {
-    // the direction of the short_channel_id. 0 for the lesser node id compared
-    // lexicographically in ascending order, 1 for the greater node id.
+    // The direction of the short_channel_id. 
+    // 0 for the lesser node id compared lexicographically in ascending order, 1 for the greater node id.
     direction: u8,
     short_channel_id: u64,
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -32,10 +32,10 @@ impl Hop {
 #[wasm_bindgen(inspectable)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct DirectedShortChannelId {
-    // The direction of the short_channel_id. 
+    // The direction of the short_channel_id.
     // 0 for the lesser node id compared lexicographically in ascending order, 1 for the greater node id.
-    direction: u8,
-    short_channel_id: u64,
+    pub direction: u8,
+    pub short_channel_id: u64,
 }
 
 impl DirectedShortChannelId {
@@ -44,13 +44,6 @@ impl DirectedShortChannelId {
             direction,
             short_channel_id,
         }
-    }
-
-    pub fn encode(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        bytes.push(self.direction);
-        bytes.extend_from_slice(&self.short_channel_id.to_be_bytes());
-        bytes
     }
 }
 
@@ -120,9 +113,8 @@ impl Path {
     }
 
     #[wasm_bindgen(getter)]
-    pub fn introduction_node_short_channel_id(&self) -> Option<Vec<u8>> {
+    pub fn introduction_node_short_channel_id(&self) -> Option<DirectedShortChannelId> {
         self.introduction_node_short_channel_id
-            .map(|scid| scid.encode())
     }
 
     #[wasm_bindgen(getter)]

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,7 +1,7 @@
 use lightning::bitcoin::secp256k1::PublicKey;
 use lightning::blinded_path::message::BlindedMessagePath;
 use lightning::blinded_path::payment::BlindedPaymentPath;
-use lightning::blinded_path::{BlindedHop, IntroductionNode};
+use lightning::blinded_path::{BlindedHop, Direction, IntroductionNode};
 use lightning::util::ser::Writeable;
 use wasm_bindgen::prelude::*;
 
@@ -30,8 +30,34 @@ impl Hop {
 }
 
 #[wasm_bindgen(inspectable)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct DirectedShortChannelId {
+    // the direction of the short_channel_id. 0 for the lesser node id compared
+    // lexicographically in ascending order, 1 for the greater node id.
+    direction: u8,
+    short_channel_id: u64,
+}
+
+impl DirectedShortChannelId {
+    pub fn from(direction: u8, short_channel_id: u64) -> Self {
+        Self {
+            direction,
+            short_channel_id,
+        }
+    }
+
+    pub fn encode(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.push(self.direction);
+        bytes.extend_from_slice(&self.short_channel_id.to_be_bytes());
+        bytes
+    }
+}
+
+#[wasm_bindgen(inspectable)]
 pub struct Path {
     introduction_node: Option<PublicKey>,
+    introduction_node_short_channel_id: Option<DirectedShortChannelId>,
     blinding_point: PublicKey,
     hops: Vec<BlindedHop>,
 }
@@ -42,6 +68,19 @@ impl Path {
             introduction_node: match path.introduction_node() {
                 IntroductionNode::NodeId(pubkey) => Some(*pubkey),
                 IntroductionNode::DirectedShortChannelId(_, _) => None,
+            },
+            introduction_node_short_channel_id: match path.introduction_node() {
+                IntroductionNode::NodeId(_) => None,
+                IntroductionNode::DirectedShortChannelId(direction, short_channel_id) => {
+                    match *direction {
+                        Direction::NodeOne => {
+                            Some(DirectedShortChannelId::from(0, *short_channel_id))
+                        }
+                        Direction::NodeTwo => {
+                            Some(DirectedShortChannelId::from(1, *short_channel_id))
+                        }
+                    }
+                }
             },
             blinding_point: path.blinding_point(),
             hops: path.blinded_hops().to_vec(),
@@ -54,6 +93,19 @@ impl Path {
                 IntroductionNode::NodeId(pubkey) => Some(*pubkey),
                 IntroductionNode::DirectedShortChannelId(_, _) => None,
             },
+            introduction_node_short_channel_id: match path.introduction_node() {
+                IntroductionNode::NodeId(_) => None,
+                IntroductionNode::DirectedShortChannelId(direction, short_channel_id) => {
+                    match *direction {
+                        Direction::NodeOne => {
+                            Some(DirectedShortChannelId::from(0, *short_channel_id))
+                        }
+                        Direction::NodeTwo => {
+                            Some(DirectedShortChannelId::from(1, *short_channel_id))
+                        }
+                    }
+                }
+            },
             blinding_point: path.blinding_point(),
             hops: path.blinded_hops().to_vec(),
         }
@@ -65,6 +117,12 @@ impl Path {
     #[wasm_bindgen(getter)]
     pub fn introduction_node(&self) -> Option<Vec<u8>> {
         self.introduction_node.map(|pubkey| pubkey.encode())
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn introduction_node_short_channel_id(&self) -> Option<Vec<u8>> {
+        self.introduction_node_short_channel_id
+            .map(|scid| scid.encode())
     }
 
     #[wasm_bindgen(getter)]

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -31,7 +31,12 @@ fn test_decode_offer_paths() {
     ).unwrap();
     let paths = offer.paths();
     assert_eq!(paths.len(), 1);
-
+    let introduction_node = paths[0].introduction_node().unwrap();
+    assert_eq!(
+        hex::encode(introduction_node),
+        "03864ef025fde8fb587d989186ce6a4a186895ee44a926bfc370e2c366597a3f8f"
+    );
+    assert_eq!(paths[0].introduction_node_short_channel_id(), None);
     let hops = paths[0].hops();
     let last_hop = hops.last().unwrap();
     assert_eq!(
@@ -48,6 +53,9 @@ fn test_decode_offer_scid_paths() {
     let paths = offer.paths();
     assert_eq!(paths.len(), 1);
 
+    assert_eq!(paths[0].introduction_node(), None);
+    let scid = paths[0].introduction_node_short_channel_id().unwrap();
+    assert_eq!(hex::encode(scid), "00000000000000002a");
     let hops = paths[0].hops();
     let last_hop = hops.last().unwrap();
     assert_eq!(

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -55,7 +55,7 @@ fn test_decode_offer_scid_paths() {
 
     assert_eq!(paths[0].introduction_node(), None);
     let scid = paths[0].introduction_node_short_channel_id().unwrap();
-    assert_eq!(hex::encode(scid), "00000000000000002a");
+    assert_eq!(scid.short_channel_id, 42);
     let hops = paths[0].hops();
     let last_hop = hops.last().unwrap();
     assert_eq!(

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -2,7 +2,7 @@
 
 extern crate wasm_bindgen_test;
 
-use boltz_bolt12::{Invoice, Offer};
+use boltz_bolt12::{Invoice, Network, Offer};
 use wasm_bindgen_test::*;
 
 wasm_bindgen_test_configure!(run_in_browser);
@@ -54,6 +54,81 @@ fn test_decode_offer_scid_paths() {
         hex::encode(last_hop.pubkey()),
         "020202020202020202020202020202020202020202020202020202020202020202"
     );
+}
+
+#[wasm_bindgen_test]
+fn test_decode_offer_multiple_chains() {
+    let offer = Offer::new(
+        "lno1qfqpge38tqmzyrdjj3x2qkdr5y80dlfw56ztq6yd9sme995g3gsxqqm0u2xq4dh3kdevrf4zg6hx8a60jv0gxe0ptgyfc6xkryqqqqqqqq9qc4r9wd6zqan9vd6x7unnzcss9mk8y3wkklfvevcrszlmu23kfrxh49px20665dqwmn4p72pksese"
+    ).unwrap();
+    let chains = offer.chains();
+    assert_eq!(chains.len(), 2);
+    assert_eq!(chains[0], Network::Unkown);
+    assert_eq!(chains[1], Network::Bitcoin);
+
+    let offer = Offer::new(
+        "lno1qgsyxjtl6luzd9t3pr62xr7eemp6awnejusgf6gw45q75vcfqqqqqqq2p32x2um5ypmx2cm5dae8x93pqthvwfzadd7jejes8q9lhc4rvjxd022zv5l44g6qah82ru5rdpnpj"
+    ).unwrap();
+    let chains = offer.chains();
+    assert_eq!(chains.len(), 1);
+    assert_eq!(chains[0], Network::Testnet3);
+}
+
+#[wasm_bindgen_test]
+fn test_decode_offer_expiry() {
+    let offer = Offer::new(
+        "lno1qgsyxjtl6luzd9t3pr62xr7eemp6awnejusgf6gw45q75vcfqqqqqqq2p32x2um5ypmx2cm5dae8x93pqthvwfzadd7jejes8q9lhc4rvjxd022zv5l44g6qah82ru5rdpnpj"
+    ).unwrap();
+    let expiry = offer.expiry();
+    assert_eq!(expiry, None);
+
+    let offer = Offer::new(
+        "lno1pgx9getnwss8vetrw3hhyucwq3ay997czcss9mk8y3wkklfvevcrszlmu23kfrxh49px20665dqwmn4p72pksese"
+    ).unwrap();
+    let expiry = offer.expiry();
+    assert_eq!(expiry, Some(2051184600));
+}
+
+#[wasm_bindgen_test]
+fn test_decode_offer_issuer() {
+    let offer = Offer::new(
+        "lno1qgsyxjtl6luzd9t3pr62xr7eemp6awnejusgf6gw45q75vcfqqqqqqq2p32x2um5ypmx2cm5dae8x93pqthvwfzadd7jejes8q9lhc4rvjxd022zv5l44g6qah82ru5rdpnpj"
+    ).unwrap();
+    let issuer = offer.issuer();
+    assert_eq!(issuer, None);
+
+    let offer = Offer::new(
+        "lno1pgx9getnwss8vetrw3hhyucjy358garswvaz7tmzdak8gvfj9ehhyeeqgf85c4p3xgsxjmnyw4ehgunfv4e3vggzamrjghtt05kvkvpcp0a79gmy3nt6jsn98ad2xs8de6sl9qmgvcvs"
+    ).unwrap();
+    let issuer = offer.issuer();
+    assert_eq!(
+        issuer,
+        Some("https://bolt12.org BOLT12 industries".to_string())
+    );
+}
+
+#[wasm_bindgen_test]
+fn test_decode_offer_quantity() {
+    let offer = Offer::new(
+        "lno1pgx9getnwss8vetrw3hhyuc5qyz3vggzamrjghtt05kvkvpcp0a79gmy3nt6jsn98ad2xs8de6sl9qmgvcvs",
+    )
+    .unwrap();
+    let quantity = offer.quantity();
+    assert_eq!(quantity, Some(5));
+
+    let offer = Offer::new(
+        "lno1pgx9getnwss8vetrw3hhyuc5qqtzzqhwcuj966ma9n9nqwqtl032xeyv6755yeflt235pmww58egx6rxry",
+    )
+    .unwrap();
+    let quantity = offer.quantity();
+    assert_eq!(quantity, Some(0));
+
+    let offer = Offer::new(
+        "lno1pgx9getnwss8vetrw3hhyuc5qyq3vggzamrjghtt05kvkvpcp0a79gmy3nt6jsn98ad2xs8de6sl9qmgvcvs",
+    )
+    .unwrap();
+    let quantity = offer.quantity();
+    assert_eq!(quantity, Some(1));
 }
 
 #[wasm_bindgen_test]

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -41,6 +41,22 @@ fn test_decode_offer_paths() {
 }
 
 #[wasm_bindgen_test]
+fn test_decode_offer_scid_paths() {
+    let offer = Offer::new(
+        "lno1pgx9getnwss8vetrw3hhyucs3yqqqqqqqqqqqqp2qgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqqyqqqqqqqqqqqqqqqqqqqqqqqqqqqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqszqgpqyqqgzyg3zyg3zyg3z93pqthvwfzadd7jejes8q9lhc4rvjxd022zv5l44g6qah82ru5rdpnpj"
+    ).unwrap();
+    let paths = offer.paths();
+    assert_eq!(paths.len(), 1);
+
+    let hops = paths[0].hops();
+    let last_hop = hops.last().unwrap();
+    assert_eq!(
+        hex::encode(last_hop.pubkey()),
+        "020202020202020202020202020202020202020202020202020202020202020202"
+    );
+}
+
+#[wasm_bindgen_test]
 fn test_decode_offer_error() {
     assert!(Offer::new("invalid").is_err());
 }

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -121,7 +121,7 @@ fn test_decode_offer_quantity() {
     )
     .unwrap();
     let quantity = offer.quantity();
-    assert_eq!(quantity, Some(0));
+    assert_eq!(quantity, None);
 
     let offer = Offer::new(
         "lno1pgx9getnwss8vetrw3hhyuc5qyq3vggzamrjghtt05kvkvpcp0a79gmy3nt6jsn98ad2xs8de6sl9qmgvcvs",


### PR DESCRIPTION
👋🏼 hey! thanks for this wasm module. I'm using it at this lightningdecoder.com [PR](https://github.com/andrerfneves/lightning-decoder/pull/94).

While working there I had an issue about SCID Paths and thought it was the library but we just for those cases using None.
But anyways, I upgraded the library to use latest rust-lightning and exposed more values that it could be used in the other PR.

Added some tests [from the vectors](https://github.com/lightning/bolts/blob/216914d492ecdf8a814bbab34fa9f6d31b394b98/bolt12/offers-test.json#L339) 

I'll be happy to add something to expose the short channels but maybe having context of why they weren't in place would be nice before updating it.